### PR TITLE
[SPARK-21548] [SQL] Support insert into serial columns of table

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -238,8 +238,8 @@ query
     ;
 
 insertInto
-    : INSERT OVERWRITE TABLE tableIdentifier (partitionSpec (IF NOT EXISTS)?)?
-    | INSERT INTO TABLE? tableIdentifier partitionSpec?
+    : INSERT OVERWRITE TABLE tableIdentifier ('(' namedExpressionSeq ')')? (partitionSpec (IF NOT EXISTS)?)?
+    | INSERT INTO TABLE? tableIdentifier ('(' namedExpressionSeq ')')? partitionSpec?
     ;
 
 partitionSpecLocation

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -624,7 +624,7 @@ class Analyzer(
           }
           execute(child)
         }
-        view.copy(child = newChild)
+        view.copy(child = newChild)cha
       case p @ SubqueryAlias(_, view: View) =>
         val newChild = resolveRelation(view)
         p.copy(child = newChild)
@@ -632,7 +632,7 @@ class Analyzer(
     }
 
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
-      case i @ InsertIntoTable(u: UnresolvedRelation, parts, child, _, _) if child.resolved =>
+      case i @ InsertIntoTable(u: UnresolvedRelation, parts, child, _, _, _) if child.resolved =>
         EliminateSubqueryAliases(lookupTableFromCatalog(u)) match {
           case v: View =>
             u.failAnalysis(s"Inserting into a view is not allowed. View: ${v.desc.identifier}.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -188,12 +188,16 @@ class AstBuilder(conf: SQLConf) extends SqlBaseBaseVisitor[AnyRef] with Logging 
         "partitions with value: " + dynamicPartitionKeys.keys.mkString("[", ",", "]"), ctx)
     }
 
+    val namedExpressions = Option(Option(ctx.namedExpressionSeq).toSeq
+      .flatMap(_.namedExpression.asScala).map(typedVisit[NamedExpression]))
+
     InsertIntoTable(
       UnresolvedRelation(tableIdent),
       partitionKeys,
       query,
       ctx.OVERWRITE != null,
-      ctx.EXISTS != null)
+      ctx.EXISTS != null,
+      namedExpressions)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -346,7 +346,8 @@ case class InsertIntoTable(
     partition: Map[String, Option[String]],
     query: LogicalPlan,
     overwrite: Boolean,
-    ifPartitionNotExists: Boolean)
+    ifPartitionNotExists: Boolean,
+    specfiedColumns: Option[Seq[NamedExpression]] = None)
   extends LogicalPlan {
   // IF NOT EXISTS is only valid in INSERT OVERWRITE
   assert(overwrite || !ifPartitionNotExists)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -137,11 +137,11 @@ case class DataSourceAnalysis(conf: SQLConf) extends Rule[LogicalPlan] with Cast
       CreateDataSourceTableAsSelectCommand(tableDesc, mode, query)
 
     case InsertIntoTable(l @ LogicalRelation(_: InsertableRelation, _, _),
-        parts, query, overwrite, false) if parts.isEmpty =>
+        parts, query, overwrite, false, _) if parts.isEmpty =>
       InsertIntoDataSourceCommand(l, query, overwrite)
 
     case i @ InsertIntoTable(
-        l @ LogicalRelation(t: HadoopFsRelation, _, table), parts, query, overwrite, _) =>
+        l @ LogicalRelation(t: HadoopFsRelation, _, table), parts, query, overwrite, _, _) =>
       // If the InsertIntoTable command is for a partitioned HadoopFsRelation and
       // the user has specified static partitions, we add a Project operator on top of the query
       // to include those constant column values in the query result.
@@ -244,7 +244,7 @@ class FindDataSourceTable(sparkSession: SparkSession) extends Rule[LogicalPlan] 
   }
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan transform {
-    case i @ InsertIntoTable(r: CatalogRelation, _, _, _, _)
+    case i @ InsertIntoTable(r: CatalogRelation, _, _, _, _, _)
         if DDLUtils.isDatasourceTable(r.tableMeta) =>
       i.copy(table = readDataSourceTable(r))
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -19,10 +19,11 @@ package org.apache.spark.sql.execution.datasources
 
 import java.util.Locale
 
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.{AnalysisException, SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.catalog._
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Expression, InputFileBlockLength, InputFileBlockStart, InputFileName, RowOrdering}
+import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.command.DDLUtils
@@ -326,14 +327,30 @@ case class PreprocessTableInsertion(conf: SQLConf) extends Rule[LogicalPlan] wit
 
     val staticPartCols = normalizedPartSpec.filter(_._2.isDefined).keySet
     val expectedColumns = insert.table.output.filterNot(a => staticPartCols.contains(a.name))
-
-    if (expectedColumns.length != insert.query.schema.length) {
+    val specfiedColumns = insert.specfiedColumns
+    validateSpecifiedColumns(specfiedColumns, expectedColumns)
+    if (specfiedColumns.isDefined && specfiedColumns.get.length !=insert.query.schema.length
+      && expectedColumns.length != insert.query.schema.length) {
       throw new AnalysisException(
         s"$tblName requires that the data to be inserted have the same number of columns as the " +
           s"target table: target table has ${insert.table.output.size} column(s) but the " +
           s"inserted data has ${insert.query.output.length + staticPartCols.size} column(s), " +
           s"including ${staticPartCols.size} partition column(s) having constant value(s).")
     }
+
+    val insertInto = if (specfiedColumns.isDefined && specfiedColumns.get.nonEmpty) {
+      insert.query match {
+        case localRelation: LocalRelation if !isSpecfiedColumnsEqExpectedColumns(
+          specfiedColumns.get, expectedColumns) =>
+          val columnNames = specfiedColumns.get.map(_.name)
+          val columnNamesIndex = columnNames.zipWithIndex.toMap
+          val fill = fillRows(columnNames, columnNamesIndex, expectedColumns)(_)
+          insert.copy(query = localRelation.copy(expectedColumns, localRelation.data
+            .map(fill)), specfiedColumns = Option(expectedColumns))
+        case _ => insert
+      }
+    }
+    else insert
 
     if (normalizedPartSpec.nonEmpty) {
       if (normalizedPartSpec.size != partColNames.length) {
@@ -345,13 +362,53 @@ case class PreprocessTableInsertion(conf: SQLConf) extends Rule[LogicalPlan] wit
            """.stripMargin)
       }
 
-      castAndRenameChildOutput(insert.copy(partition = normalizedPartSpec), expectedColumns)
+      castAndRenameChildOutput(insertInto.copy(partition = normalizedPartSpec), expectedColumns)
     } else {
       // All partition columns are dynamic because the InsertIntoTable command does
       // not explicitly specify partitioning columns.
-      castAndRenameChildOutput(insert, expectedColumns)
+      castAndRenameChildOutput(insertInto, expectedColumns)
         .copy(partition = partColNames.map(_ -> None).toMap)
     }
+  }
+
+  def validateSpecifiedColumns(specfiedColumns: Option[Seq[NamedExpression]],
+                               expectedColumns: Seq[Attribute]): Unit = {
+    val specfiedColumnNames = specfiedColumns.get.map(_.name)
+    if(specfiedColumnNames.distinct.length != specfiedColumnNames.length)
+    {
+      throw new AnalysisException(s"Cannot insert into table " +
+          s"because there are Repeated columns in the specfied columns")
+    }
+    val expectedColumnNames = expectedColumns.map(_.name)
+    if(specfiedColumnNames.exists(!expectedColumnNames.contains(_)))
+    {
+      throw new AnalysisException(s"Cannot insert into table " +
+        s"because there are columns in the specfied columns not existed in expected Columns")
+    }
+  }
+
+  def fillRows(columnNames: Seq[String], columnNamesIndex: Map[String, Int],
+               expectedColumns: Seq[Attribute])
+              (row: InternalRow): InternalRow = {
+    var data = Seq[AnyRef]()
+    expectedColumns.foreach(column => {
+      val line = if (columnNames.contains(column.name) &&
+        !row.isNullAt(columnNamesIndex(column.name))) {
+        row.get(columnNamesIndex(column.name), column.dataType)
+      }
+      else {
+        null
+      }
+      data = data.:+(line)
+    })
+    InternalRow(data: _*)
+  }
+
+  def isSpecfiedColumnsEqExpectedColumns(specfiedColumns: Seq[NamedExpression], expectedColumns:
+  Seq[Attribute]): Boolean = {
+    val result = expectedColumns.map(_.name).zipAll(specfiedColumns.map(_.name), None,
+      None).count(line => line._1 != line._2)
+    result==0
   }
 
   private def castAndRenameChildOutput(
@@ -380,7 +437,7 @@ case class PreprocessTableInsertion(conf: SQLConf) extends Rule[LogicalPlan] wit
   }
 
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
-    case i @ InsertIntoTable(table, _, query, _, _) if table.resolved && query.resolved =>
+    case i @ InsertIntoTable(table, _, query, _, _, _) if table.resolved && query.resolved =>
       table match {
         case relation: CatalogRelation =>
           val metadata = relation.tableMeta
@@ -454,7 +511,7 @@ object PreWriteCheck extends (LogicalPlan => Unit) {
 
   def apply(plan: LogicalPlan): Unit = {
     plan.foreach {
-      case InsertIntoTable(l @ LogicalRelation(relation, _, _), partition, query, _, _) =>
+      case InsertIntoTable(l @ LogicalRelation(relation, _, _), partition, query, _, _, _) =>
         // Get all input data source relations of the query.
         val srcRelations = query.collect {
           case LogicalRelation(src, _, _) => src
@@ -476,7 +533,7 @@ object PreWriteCheck extends (LogicalPlan => Unit) {
           case _ => failAnalysis(s"$relation does not allow insertion.")
         }
 
-      case InsertIntoTable(t, _, _, _, _)
+      case InsertIntoTable(t, _, _, _, _, _)
         if !t.isInstanceOf[LeafNode] ||
           t.isInstanceOf[Range] ||
           t == OneRowRelation ||

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -147,7 +147,7 @@ class DetermineTableStats(session: SparkSession) extends Rule[LogicalPlan] {
  */
 object HiveAnalysis extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
-    case InsertIntoTable(r: CatalogRelation, partSpec, query, overwrite, ifPartitionNotExists)
+    case InsertIntoTable(r: CatalogRelation, partSpec, query, overwrite, ifPartitionNotExists, _)
         if DDLUtils.isHiveTable(r.tableMeta) =>
       InsertIntoHiveTable(r.tableMeta, partSpec, query, overwrite, ifPartitionNotExists)
 
@@ -194,7 +194,7 @@ case class RelationConversions(
   override def apply(plan: LogicalPlan): LogicalPlan = {
     plan transformUp {
       // Write path
-      case InsertIntoTable(r: CatalogRelation, partition, query, overwrite, ifPartitionNotExists)
+      case InsertIntoTable(r: CatalogRelation, partition, query, overwrite, ifPartitionNotExists, _)
         // Inserting into partitioned table is not supported in Parquet/Orc data source (yet).
           if query.resolved && DDLUtils.isHiveTable(r.tableMeta) &&
             !r.isPartitioned && isConvertible(r) =>


### PR DESCRIPTION
## What changes were proposed in this pull request?
When we use the 'insert into ...' statement we can only insert all the columns into table.But int some cases,our table has many columns and we are only interest in some of them.So we want to support the statement "insert into table tbl (column1, column2,...) values (value1, value2, value3,...)".
https://issues.apache.org/jira/browse/SPARK-21548

## How was this patch tested?
manual tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
